### PR TITLE
CI/CD: PR checks, WIF-authenticated deploys from main, hosting previews (#8)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -37,6 +37,12 @@ automated-directory-agent/
   live in `firestore.rules` / `firestore.indexes.json`, deployed with
   `firebase deploy --only firestore`. TTL on `rateLimits.expiresAt` is the one piece
   the Firebase CLI can't do — `scripts/provisionFirestore.sh` (idempotent gcloud)
+- CI/CD (issue #8): GitHub Actions in `.github/workflows/` — `ci.yml` PR checks
+  (`functions` + `web` jobs, required by main's branch protection), `eval.yml`
+  path-filtered retrieval gate (needs `GEMINI_API_KEY` repo secret), `deploy.yml`
+  deploys functions+hosting+firestore on push to main, `preview.yml` hosting
+  preview channels on web PRs. GCP auth is Direct Workload Identity Federation
+  (pool `github`, provider `adagent-repo`, scoped to this repo; no SA keys)
 
 ## Commands
 
@@ -127,16 +133,14 @@ Rationale: real player traffic is both the requirements document for Issue #6 (w
 wiki content/aliases matter) and the observed-miss generator the saturated eval gold
 set needs. Do NOT build #6 first in isolation.
 
-1. **#7 Instrumentation** (pre-publish prerequisite): Genkit telemetry, durable
-   per-turn records (question → tool calls → top-K + scores → answer) in the
-   `turns` Firestore collection, thumbs up/down in web UI, strategy-question
-   guardrail in `adagent.prompt`, rate limiting
-2. **Soft-launch** to a small player circle (beta framing) once #7 lands
+1. **#7 Instrumentation** — DONE, merged (PR #12) and deployed to prod 2026-07-06
+2. **Soft-launch** to a small player circle (beta framing) — UNBLOCKED, next up
 3. **#6 Wiki RAG** built during the traffic-collection window, informed by it — parallel
    index + `searchWikiGuides` tool; the eval framework (`src/eval/metrics.ts`,
    gold-set schema) is source-agnostic and reusable; traffic-derived cases (e.g.
    gold-set `syn-03` "HOR") become its acceptance tests
-4. **In parallel:** #8 CI/CD (PR checks + deploys from main), #9 move the ~74MB
+4. **In parallel:** #8 CI/CD (PR checks + deploys from main — implemented, see
+   Infrastructure above), #9 move the ~74MB
    `game_data_index.json` out of git (history bloat per rebuild), #10 Layer-3
    LLM-judge answer-accuracy eval (where #6 acceptance tests and #7 thumbs-down
    triage converge)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+# PR checks (issue #8): a PR cannot merge unless both jobs pass — they are
+# required status checks in main's branch protection. Job names ("functions",
+# "web") are referenced there; rename them in both places or not at all.
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  functions:
+    name: functions
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: functions
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: functions/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm test
+
+  web:
+    name: web
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v5
+      # web/package.json pins packageManager: pnpm@10.x; pnpm 11 self-switches
+      # to that version when invoked inside web/.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+# Deploy from main (issue #8): functions + hosting + firestore rules/indexes
+# in one `firebase deploy`, authenticated via Direct Workload Identity
+# Federation — no long-lived keys. The WIF pool/provider and IAM grants are
+# provisioned outside this file (see scripts/provisionFirestore.sh header for
+# the pattern); the provider is scoped to this repository only.
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+# Queue deploys instead of cancelling: a half-cancelled firebase deploy can
+# leave functions and hosting on different revisions.
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: |
+            functions/pnpm-lock.yaml
+            web/pnpm-lock.yaml
+      # firebase.json's functions predeploy (format → lint → build) runs pnpm
+      # inside functions/, so deps must be installed before `firebase deploy`.
+      - name: Install functions dependencies
+        working-directory: functions
+        run: pnpm install --frozen-lockfile
+      - name: Build web (Nuxt SSG)
+        working-directory: web
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+      - uses: google-github-actions/auth@v3
+        with:
+          project_id: ficsit-forge
+          workload_identity_provider: projects/475186372635/locations/global/workloadIdentityPools/github/providers/adagent-repo
+      - name: Deploy functions + hosting + firestore
+        run: >
+          pnpm dlx firebase-tools@latest deploy
+          --only functions,hosting:adagent,firestore
+          --project ficsit-forge --non-interactive --force

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,0 +1,41 @@
+# Retrieval-quality gate (issue #8): runs `pnpm eval` (Hit@K/MRR vs
+# eval/baseline-metrics.json) only when retrieval-relevant inputs change.
+# Needs the GEMINI_API_KEY repo secret to embed the ~34 gold-set queries.
+# Deliberately NOT a required check — it only runs on these paths.
+name: Retrieval eval
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "functions/src/data/**"
+      - "functions/eval/**"
+      - "functions/game_data_index.json"
+      - "functions/scripts/evalRetrieval.ts"
+      - "functions/scripts/buildIndex.ts"
+
+concurrency:
+  group: eval-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  eval:
+    name: retrieval-eval
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: functions
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: functions/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm eval
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,51 @@
+# Hosting preview channels on PRs that touch web/ (issue #8 nice-to-have).
+# Skipped for fork PRs: they cannot mint OIDC tokens for our WIF provider.
+# The preview URL lands in the job summary (7-day expiry).
+name: Hosting preview
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "web/**"
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  preview:
+    name: hosting-preview
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+      - name: Build web (Nuxt SSG)
+        working-directory: web
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+      - uses: google-github-actions/auth@v3
+        with:
+          project_id: ficsit-forge
+          workload_identity_provider: projects/475186372635/locations/global/workloadIdentityPools/github/providers/adagent-repo
+      - name: Deploy preview channel
+        run: |
+          pnpm dlx firebase-tools@latest hosting:channel:deploy "pr-${{ github.event.number }}" \
+            --project ficsit-forge --expires 7d | tee channel.log
+          {
+            echo "### Hosting preview"
+            grep -Eo 'https://[^ ]*web\.app[^ ]*' channel.log | head -1
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Implements issue #8 — automated checks on PRs and keyless deploys from main.

**Workflows** (`.github/workflows/`):
- **ci.yml** — `functions` (pnpm build + 112 vitest tests) and `web` (pnpm build) jobs on every PR. Both are required status checks on `main` with `strict: true` (branch must be up to date before merging), so a PR cannot merge with failing build/tests and a stale-branch merge can't ship a logically-conflicting change straight to prod.
- **eval.yml** — Layer-2 retrieval gate (`pnpm eval`, Hit@K/MRR vs baseline), path-filtered to retrieval-relevant changes (`src/data/**`, `eval/**`, index, eval/index scripts). Uses the `GEMINI_API_KEY` repo secret (~34 embed calls per run). Not a required check since it only runs on those paths.
- **deploy.yml** — on push to `main`: builds web (Nuxt SSG), then `firebase deploy --only functions,hosting:adagent,firestore`. Queued (not cancelled) per-branch concurrency so deploys never half-cancel.
- **preview.yml** — Firebase Hosting preview channel `pr-<N>` (7-day expiry) on PRs touching `web/`; URL in the job summary; skipped for forks (no WIF for fork tokens).

**Auth — no long-lived credentials** (acceptance criterion): Direct Workload Identity Federation via `google-github-actions/auth@v3`. Provisioned:
- WIF pool `github` + OIDC provider `adagent-repo` with attribute condition `assertion.repository == 'FICSIT-Forge/automated-directory-agent'`
- Least-privilege project grants to the repo principal: `firebasehosting.admin`, `cloudfunctions.developer`, `firebaserules.admin`, `datastore.indexAdmin`, `secretmanager.viewer`, `serviceusage.serviceUsageConsumer`, `firebase.viewer`, plus `iam.serviceAccountUser` scoped to the functions runtime SA only

**Hygiene:** secret scanning + push protection verified already enabled (public-repo defaults). Renovate already active via the GitHub app — left as-is.

## Verification

- This PR exercises `ci.yml` itself — the `functions` and `web` required checks below are the acceptance test for PR checks.
- `deploy.yml` can only be proven on merge to main; prod is currently already at parity (manual deploy of `3ad16b0` earlier today), so the first CI deploy is a safe no-op-equivalent redeploy.
- Branch protection verified via API: `{"contexts":["functions","web"],"strict":true}`.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)