### PR TITLE
ci: dump firebase-debug.log on deploy failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,3 +54,8 @@ jobs:
           pnpm dlx firebase-tools@latest deploy
           --only functions,hosting:adagent,firestore
           --project ficsit-forge --non-interactive --force
+      # firebase-tools prints only "An unexpected error has occurred." for
+      # uncaught exceptions; the stack goes to firebase-debug.log.
+      - name: Dump firebase-debug.log on failure
+        if: failure()
+        run: tail -n 200 firebase-debug.log


### PR DESCRIPTION
The first main deploy (run 28808662395) failed with firebase-tools' generic "An unexpected error has occurred." — the actual stack trace only goes to firebase-debug.log. This adds an `if: failure()` step that tails it so the next failing run is diagnosable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)