### PR TITLE
ci: pin firebase-tools to 15.22.1 (WIF auth regression in 15.22.2+)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,9 +49,13 @@ jobs:
         with:
           project_id: ficsit-forge
           workload_identity_provider: projects/475186372635/locations/global/workloadIdentityPools/github/providers/adagent-repo
+      # Pinned to 15.22.1: 15.22.2+ has a WIF/ADC auth regression (crashes on
+      # external_account credentials — firebase/firebase-tools#10716; here it
+      # surfaced as "Cannot read properties of undefined (reading
+      # 'access_token')"). Unpin once the fix ships and a WIF deploy succeeds.
       - name: Deploy functions + hosting + firestore
         run: >
-          pnpm dlx firebase-tools@latest deploy
+          pnpm dlx firebase-tools@15.22.1 deploy
           --only functions,hosting:adagent,firestore
           --project ficsit-forge --non-interactive --force
       # firebase-tools prints only "An unexpected error has occurred." for

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -41,9 +41,11 @@ jobs:
         with:
           project_id: ficsit-forge
           workload_identity_provider: projects/475186372635/locations/global/workloadIdentityPools/github/providers/adagent-repo
+      # Pinned to 15.22.1 for the WIF auth regression in 15.22.2+
+      # (firebase/firebase-tools#10716) — keep in sync with deploy.yml.
       - name: Deploy preview channel
         run: |
-          pnpm dlx firebase-tools@latest hosting:channel:deploy "pr-${{ github.event.number }}" \
+          pnpm dlx firebase-tools@15.22.1 hosting:channel:deploy "pr-${{ github.event.number }}" \
             --project ficsit-forge --expires 7d | tee channel.log
           {
             echo "### Hosting preview"


### PR DESCRIPTION
Deploy run 28825035758 failed with `TypeError: Cannot read properties of undefined (reading 'access_token')` after every IAM preflight passed (visible thanks to the debug-log dump from #14). Root cause is the known ADC/WIF auth regression introduced in firebase-tools 15.22.2 ([firebase/firebase-tools#10716](https://github.com/firebase/firebase-tools/issues/10716)); `@latest` resolves to 15.22.4 which is still affected. Pins both deploy and preview workflows to the last known-good 15.22.1, with comments to unpin once the upstream fix ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)