### PR TITLE
ci: WIF service-account impersonation + least-privilege custom role

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,14 +45,20 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm build
+      # WIF with service-account impersonation, NOT direct WIF: firebase-tools
+      # crashes on direct external_account credentials (its ADC token cache
+      # reads tokens that are never populated — "Cannot read properties of
+      # undefined (reading 'access_token')", seen on 15.22.1 and 15.22.4).
+      # Impersonation mints short-lived tokens with a client_email, the shape
+      # firebase-tools handles. Still keyless: no exported SA keys.
       - uses: google-github-actions/auth@v3
         with:
           project_id: ficsit-forge
           workload_identity_provider: projects/475186372635/locations/global/workloadIdentityPools/github/providers/adagent-repo
-      # Pinned to 15.22.1: 15.22.2+ has a WIF/ADC auth regression (crashes on
-      # external_account credentials — firebase/firebase-tools#10716; here it
-      # surfaced as "Cannot read properties of undefined (reading
-      # 'access_token')"). Unpin once the fix ships and a WIF deploy succeeds.
+          service_account: github-deployer@ficsit-forge.iam.gserviceaccount.com
+      # Pinned to 15.22.1: 15.22.2+ has a WIF/ADC auth regression
+      # (firebase/firebase-tools#10716). Unpin once the fix ships and a WIF
+      # deploy succeeds.
       - name: Deploy functions + hosting + firestore
         run: >
           pnpm dlx firebase-tools@15.22.1 deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -37,10 +37,12 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm build
+      # Impersonation required — see the note in deploy.yml.
       - uses: google-github-actions/auth@v3
         with:
           project_id: ficsit-forge
           workload_identity_provider: projects/475186372635/locations/global/workloadIdentityPools/github/providers/adagent-repo
+          service_account: github-deployer@ficsit-forge.iam.gserviceaccount.com
       # Pinned to 15.22.1 for the WIF auth regression in 15.22.2+
       # (firebase/firebase-tools#10716) — keep in sync with deploy.yml.
       - name: Deploy preview channel


### PR DESCRIPTION
## Problem
Deploy runs 28808662395 / 28825035758 / 28825399994 failed. The debug log (added in #14) shows `TypeError: Cannot read properties of undefined (reading 'access_token')` in `apiv2.js getAccessToken()` after all IAM preflights pass. Root cause: firebase-tools' ADC refresh path (`refreshAuth()` → `lastOptions.tokens`) only populates tokens in a Firebase-Studio-specific branch, so direct-WIF `external_account` credentials crash it. Reproduced on both 15.22.1 and 15.22.4 — version pinning alone doesn't fix it.

## Fix
Authenticate via WIF **impersonating a dedicated service account** (`google-github-actions/auth@v3` with `service_account:`) — impersonated credentials carry a `client_email` and mint token shapes the CLI handles; this is also how working community WIF-deploy actions do it. No long-lived keys anywhere.

## IAM changes (least-privilege, per review feedback)
- New custom role `adagentDeployer`: exactly the 33 permissions this deploy performs (functions CRUD + operations, hosting sites.update, rules rulesets/releases, datastore indexes, secret read, serviceusage get/list/use, artifactregistry repo get/update, project get) — no predefined `*.admin` roles
- New SA `github-deployer@ficsit-forge`: custom role + `iam.serviceAccountUser` on the two runtime SAs only
- Repo WIF principal: **zero** direct project roles now — only `roles/iam.workloadIdentityUser` on `github-deployer` (verified: project IAM policy has no remaining bindings for the principal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)