### PR TITLE
fix(web): send App Check header synchronously (transport doesn't await headers fn)

### DIFF
--- a/web/app/utils/firebase.ts
+++ b/web/app/utils/firebase.ts
@@ -6,17 +6,24 @@
  * App Check tokens are attached to agent requests as the X-Firebase-AppCheck
  * header (verified by Express middleware server-side — the agent endpoint is
  * an HTTP function, not a callable, so the SDK doesn't do this for us).
+ *
+ * GOTCHA: GenkitChatTransport calls its `headers` function WITHOUT awaiting
+ * it (client.js resolveHeaders, @genkit-ai/vercel-ai 0.2.0), so it must be
+ * synchronous — an async function's Promise spreads to an empty object and
+ * the header silently disappears. We therefore keep the current token in a
+ * module variable via onTokenChanged (primed once at init; the SDK
+ * auto-refreshes it) and read it synchronously per request.
  */
 
 import { initializeApp } from "firebase/app";
 import {
   getToken,
   initializeAppCheck,
+  onTokenChanged,
   ReCaptchaEnterpriseProvider,
-  type AppCheck,
 } from "firebase/app-check";
 
-let appCheck: AppCheck | undefined;
+let currentToken: string | undefined;
 let initialized = false;
 
 export async function initFirebase(recaptchaSiteKey?: string): Promise<void> {
@@ -29,18 +36,26 @@ export async function initFirebase(recaptchaSiteKey?: string): Promise<void> {
   // Creates the default app, which getFunctions() (feedback) relies on too.
   const app = initializeApp(await response.json());
   if (recaptchaSiteKey) {
-    appCheck = initializeAppCheck(app, {
+    const appCheck = initializeAppCheck(app, {
       provider: new ReCaptchaEnterpriseProvider(recaptchaSiteKey),
       isTokenAutoRefreshEnabled: true,
     });
+    onTokenChanged(appCheck, (result) => {
+      currentToken = result.token;
+    });
+    // Prime the first token before the initial prompt goes out.
+    try {
+      currentToken = (await getToken(appCheck)).token;
+    } catch (e) {
+      console.error("App Check token fetch failed:", e);
+    }
   }
   initialized = true;
 }
 
-/** Per-request headers for the agent endpoints. Empty when App Check is not
- * configured (local dev — the emulator server skips verification). */
-export async function appCheckHeaders(): Promise<Record<string, string>> {
-  if (!appCheck) return {};
-  const { token } = await getToken(appCheck);
-  return { "X-Firebase-AppCheck": token };
+/** Synchronous per-request headers for the agent endpoints — see GOTCHA
+ * above. Empty when App Check is not configured (local dev — the emulator
+ * server skips verification). */
+export function appCheckHeaders(): Record<string, string> {
+  return currentToken ? { "X-Firebase-AppCheck": currentToken } : {};
 }


### PR DESCRIPTION
Post-#19 prod bug: chat requests failed with our middleware's 401 "App Check token missing". Root cause in `@genkit-ai/vercel-ai` 0.2.0 `client.js` `resolveHeaders`:

```js
const base = typeof this.headersConfig === "function" ? this.headersConfig() : this.headersConfig;
...
return { ...base, ...extraRecord };
```

The function result is not awaited — our async `appCheckHeaders()` returned a Promise, which spreads to `{}`, silently dropping the header. Fix: maintain the current App Check token in a module variable via `onTokenChanged` (primed during `initFirebase`, before the initial prompt sends; SDK auto-refresh keeps it fresh) and make `appCheckHeaders()` synchronous.

Worth filing upstream: the `headers` option should either await function results or its type should forbid async functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)