### PR TITLE
Fix 1000× fluid amounts in the game data index (liters → m³)

### DIFF
--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -26,3 +26,4 @@ eval/reddit-candidates.json
 # mineLogs output — raw input for hand-labeling, not an artifact
 eval/log-candidates.json
 firestore-debug.log
+eval/turn-candidates.json

--- a/functions/eval/accuracy_dataset.json
+++ b/functions/eval/accuracy_dataset.json
@@ -38,5 +38,15 @@
     "testCaseId": "base_building_milestone",
     "input": "What does the Base Building milestone unlock?",
     "reference": "Base Building is a Tier 1 milestone that costs 200x Concrete, 100x Iron Plate, and 100x Iron Rod. It unlocks the Lookout Tower, Foundation (1m, 2m, 4m), Ramp (1m, 2m, 4m), and Basic Wall (4m, 1m)."
+  },
+  {
+    "testCaseId": "nuclear_fuel_rod_types",
+    "input": "What kind of nuclear fuel rods can I provide to nuclear power plant?",
+    "reference": "The Nuclear Power Plant (2500 MW) accepts three fuel rod types. (1) Uranium Fuel Rod: 750,000 MJ, produces Uranium Waste; made in a Manufacturer (150s): 50x Encased Uranium Cell (20/min), 3x Encased Industrial Beam (1.2/min), 5x Electromagnetic Control Rod (2/min) → 1 rod (0.4/min). (2) Plutonium Fuel Rod: 1,500,000 MJ, produces Plutonium Waste; Manufacturer (240s): 30x Encased Plutonium Cell (7.5/min), 18x Steel Beam (4.5/min), 6x Electromagnetic Control Rod (1.5/min), 10x Heat Sink (2.5/min) → 1 rod (0.25/min). (3) Ficsonium Fuel Rod: 150,000 MJ, no waste; Quantum Encoder (24s): 2x Ficsonium (5/min), 2x Electromagnetic Control Rod (5/min), 40x Ficsite Trigon (100/min), 20 m³ Excited Photonic Matter (50/min) → 1 rod (2.5/min) + 20 m³ Dark Matter Residue (50/min). Fluid rates are in m³ — production turn 2026-07-08 repeated 1000× inflated values (issue #22)."
+  },
+  {
+    "testCaseId": "fluid_and_solid_input_machines",
+    "input": "What other machines accept both fluid and solid inputs?",
+    "reference": "Machines with both Conveyor (solid) and Pipeline (fluid) ports: Refinery (30 MW), Blender (75 MW), Packager (10 MW), Converter, Quantum Encoder, and Particle Accelerator (some recipes); plus the Coal-Powered Generator (fuel + 45 m³/min Water) and Nuclear Power Plant (fuel rods + 240 m³/min Water). Any recipe examples given must come from tool results — a production turn 2026-07-08 invented a Ficsite Ingot (Iron) recipe using Iron Ore and Nitrogen Gas; the real recipe is 4x Reanimated SAM (40/min) + 24x Iron Ingot (240/min) → 1x Ficsite Ingot (10/min) in the Converter, no gas involved."
   }
 ]

--- a/functions/src/data/parser.test.ts
+++ b/functions/src/data/parser.test.ts
@@ -50,6 +50,23 @@ const RAW_DOCS = [
         mStackSize: "SS_HUGE",
         mEnergyValue: "300",
       },
+      {
+        // Fluid: Docs.json stores its recipe amounts in liters (issue #22).
+        ClassName: "Desc_LiquidOil_C",
+        mDisplayName: "Crude Oil",
+        mDescription: "Raw oil.",
+        mForm: "RF_LIQUID",
+        mStackSize: "SS_FLUID",
+        mEnergyValue: "0",
+      },
+      {
+        ClassName: "Desc_HeavyOilResidue_C",
+        mDisplayName: "Heavy Oil Residue",
+        mDescription: "Byproduct.",
+        mForm: "RF_LIQUID",
+        mStackSize: "SS_FLUID",
+        mEnergyValue: "0",
+      },
     ],
   },
   {
@@ -130,6 +147,42 @@ const RAW_DOCS = [
         mProduct: `(${itemAmount("Desc_IronPlate", 20)})`,
         mManufactoringDuration: "24.0",
         mProducedIn: `("${assetPath("Build_ConstructorMk1")}")`,
+      },
+      {
+        // Fluid amounts arrive in liters (3000 = 3 m³): the real Plastic
+        // recipe shape, mixing a fluid ingredient with solid + fluid products.
+        ClassName: "Recipe_Plastic_C",
+        mDisplayName: "Plastic",
+        mIngredients: `(${itemAmount("Desc_LiquidOil", 3000)})`,
+        mProduct: `(${itemAmount("Desc_IronPlate", 2)},${itemAmount("Desc_HeavyOilResidue", 1000)})`,
+        mManufactoringDuration: "6.0",
+        mProducedIn: `("${assetPath("Build_ConstructorMk1")}")`,
+      },
+    ],
+  },
+  {
+    NativeClass:
+      "/Script/CoreUObject.Class'/Script/FactoryGame.FGBuildableWaterPump'",
+    Classes: [
+      {
+        ClassName: "Build_WaterPump_C",
+        mDisplayName: "Water Extractor",
+        mDescription: "Extracts water.",
+        mExtractCycleTime: "1.0",
+        mItemsPerCycle: "2000",
+        mPowerConsumption: "20",
+        mAllowedResourceForms: "(RF_LIQUID)",
+      },
+      {
+        // Placeholder mItemsPerCycle=1 (Resource Well Pressurizer shape):
+        // must NOT be liter-scaled despite fluid-only forms.
+        ClassName: "Build_Pressurizer_C",
+        mDisplayName: "Pressurizer",
+        mDescription: "Pressurizes wells.",
+        mExtractCycleTime: "1.0",
+        mItemsPerCycle: "1",
+        mPowerConsumption: "150",
+        mAllowedResourceForms: "(RF_LIQUID,RF_GAS,(INVALID))",
       },
     ],
   },
@@ -241,10 +294,11 @@ describe("DataParser.parse", () => {
     for (const e of entities)
       counts.set(e.entityType, (counts.get(e.entityType) ?? 0) + 1);
 
-    expect(counts.get("item")).toBe(3);
+    expect(counts.get("item")).toBe(5);
     expect(counts.get("manufacturer")).toBe(1);
     expect(counts.get("generator")).toBe(1);
-    expect(counts.get("recipe")).toBe(4);
+    expect(counts.get("extractor")).toBe(2);
+    expect(counts.get("recipe")).toBe(5);
     // Only the two milestones: EST_Alternate and EST_Tutorial are excluded.
     expect(counts.get("schematic")).toBe(2);
     // Customization recipes and building descriptors produce no entities.
@@ -287,6 +341,41 @@ describe("DataParser.parse", () => {
       expect(recipe.metadata.producedIn).toEqual(["Constructor"]);
     });
 
+    it("scales fluid amounts from liters to m³ and renders the unit (issue #22)", () => {
+      const recipe = byName<RecipeEntity>("recipe", "Plastic");
+      expect(recipe.metadata.ingredients).toEqual([
+        {
+          className: "Desc_LiquidOil_C",
+          displayName: "Crude Oil",
+          amount: 3,
+          ratePerMin: 30,
+          isFluid: true,
+        },
+      ]);
+      // Solid product untouched, fluid product scaled.
+      expect(recipe.metadata.products).toEqual([
+        {
+          className: "Desc_IronPlate_C",
+          displayName: "Iron Plate",
+          amount: 2,
+          ratePerMin: 20,
+        },
+        {
+          className: "Desc_HeavyOilResidue_C",
+          displayName: "Heavy Oil Residue",
+          amount: 1,
+          ratePerMin: 10,
+          isFluid: true,
+        },
+      ]);
+      expect(recipe.embeddingText).toContain(
+        "Ingredients: 3 m³ Crude Oil (30/min)",
+      );
+      expect(recipe.embeddingText).toContain(
+        "Products: 2x Iron Plate (20/min), 1 m³ Heavy Oil Residue (10/min)",
+      );
+    });
+
     it("flags alternate recipes by name and className", () => {
       const alt = byName<RecipeEntity>("recipe", "Alternate: Cast Screw");
       expect(alt.metadata.isAlternate).toBe(true);
@@ -294,6 +383,20 @@ describe("DataParser.parse", () => {
       expect(
         byName<RecipeEntity>("recipe", "Iron Plate").metadata.isAlternate,
       ).toBe(false);
+    });
+  });
+
+  describe("extractors", () => {
+    it("scales fluid extraction rates from liters to m³ (issue #22)", () => {
+      const pump = byName("extractor", "Water Extractor");
+      expect(pump.embeddingText).toContain("Base extraction rate: 120 m³/min");
+    });
+
+    it("does not scale placeholder itemsPerCycle values", () => {
+      const pressurizer = byName("extractor", "Pressurizer");
+      expect(pressurizer.embeddingText).toContain(
+        "Base extraction rate: 60/min",
+      );
     });
   });
 

--- a/functions/src/data/parser.ts
+++ b/functions/src/data/parser.ts
@@ -135,6 +135,7 @@ export class DataParser {
    */
   public parse(): GameEntity[] {
     const nameLookup = this.buildNameLookup();
+    const fluidClasses = this.buildFluidLookup();
     const entities: GameEntity[] = [];
     this.hardDriveRecipeClasses = new Set();
 
@@ -168,7 +169,7 @@ export class DataParser {
       ) {
         for (const cls of group.Classes) {
           if (cls.mDisplayName)
-            entities.push(this.parseRecipe(cls, nc, nameLookup));
+            entities.push(this.parseRecipe(cls, nc, nameLookup, fluidClasses));
         }
       } else if (nc.includes(SCHEMATIC_PATTERN)) {
         for (const cls of group.Classes) {
@@ -211,6 +212,21 @@ export class DataParser {
     }
     this.resolveDescriptorNames(lookup);
     return lookup;
+  }
+
+  /** ClassNames of items whose form is Liquid or Gas — their amounts in
+   * Docs.json are liters and need ÷1000 scaling to m³ (issue #22). */
+  private buildFluidLookup(): Set<string> {
+    const fluids = new Set<string>();
+    for (const group of this.rawData) {
+      for (const cls of group.Classes) {
+        const form = cls.mForm as string | undefined;
+        if (form === "RF_LIQUID" || form === "RF_GAS") {
+          fluids.add(cls.ClassName);
+        }
+      }
+    }
+    return fluids;
   }
 
   /**
@@ -286,13 +302,26 @@ export class DataParser {
     item: { className: string; amount: number },
     durationSecs: number,
     lookup: Map<string, string>,
+    fluidClasses: ReadonlySet<string>,
   ): ResolvedAmount {
+    // Docs.json stores Liquid/Gas amounts in liters; the game displays m³
+    // (issue #22). Without this, every fluid in every recipe is 1000× off —
+    // and the model faithfully repeats it ("50,000/min Excited Photonic
+    // Matter" reached a real player).
+    const isFluid = fluidClasses.has(item.className);
+    const amount = isFluid ? item.amount / 1000 : item.amount;
     return {
       className: item.className,
       displayName: this.resolveName(item.className, lookup),
-      amount: item.amount,
-      ratePerMin: Math.round((item.amount / durationSecs) * 60 * 100) / 100,
+      amount,
+      ratePerMin: Math.round((amount / durationSecs) * 60 * 100) / 100,
+      ...(isFluid ? { isFluid } : {}),
     };
+  }
+
+  /** `3x Iron Ingot (30/min)` for solids, `3 m³ Crude Oil (30/min)` for fluids. */
+  private formatAmount(a: ResolvedAmount): string {
+    return `${a.amount}${a.isFluid ? " m³" : "x"} ${a.displayName} (${a.ratePerMin}/min)`;
   }
 
   private parseFuels(
@@ -441,11 +470,22 @@ export class DataParser {
     const name = cls.mDisplayName as string;
     const desc = this.cleanDescription(cls.mDescription);
     const cycleSecs = this.parseNumber(cls.mExtractCycleTime) || 1;
-    const itemsPerCycle = this.parseNumber(cls.mItemsPerCycle) || 1;
+    const rawItemsPerCycle = this.parseNumber(cls.mItemsPerCycle) || 1;
     const powerMW = this.parseNumber(cls.mPowerConsumption);
+    // Fluid extractors (Water/Oil/Resource Well) report mItemsPerCycle in
+    // liters, like recipe fluid amounts (issue #22). The ≥1000 guard protects
+    // entities with placeholder values (Resource Well Pressurizer has
+    // mItemsPerCycle=1 and no real extraction rate of its own).
+    const forms = (cls.mAllowedResourceForms as string) || "";
+    const isFluid =
+      /RF_LIQUID|RF_GAS/.test(forms) &&
+      !forms.includes("RF_SOLID") &&
+      rawItemsPerCycle >= 1000;
+    const itemsPerCycle = isFluid ? rawItemsPerCycle / 1000 : rawItemsPerCycle;
     const ratePerMin = Math.round(
       ((itemsPerCycle / cycleSecs) * 60 * 100) / 100,
     );
+    const rateUnit = isFluid ? " m³/min" : "/min";
 
     return {
       className: cls.ClassName,
@@ -463,7 +503,7 @@ export class DataParser {
       embeddingText: [
         `Building: ${name} (Resource Extractor)`,
         `Description: ${desc}`,
-        `Base extraction rate: ${ratePerMin}/min`,
+        `Base extraction rate: ${ratePerMin}${rateUnit}`,
         `Power consumption: ${powerMW} MW`,
       ].join("\n"),
     };
@@ -473,6 +513,7 @@ export class DataParser {
     cls: RawClass,
     nativeClass: string,
     nameLookup: Map<string, string>,
+    fluidClasses: ReadonlySet<string>,
   ): RecipeEntity {
     const name = cls.mDisplayName as string;
     const durationSecs = this.parseNumber(cls.mManufactoringDuration) || 1;
@@ -481,10 +522,13 @@ export class DataParser {
 
     const ingredients = parseItemAmountList(
       (cls.mIngredients as string) || "",
-    ).map((item) => this.resolveAmount(item, durationSecs, nameLookup));
+    ).map((item) =>
+      this.resolveAmount(item, durationSecs, nameLookup, fluidClasses),
+    );
 
     const products = parseItemAmountList((cls.mProduct as string) || "").map(
-      (item) => this.resolveAmount(item, durationSecs, nameLookup),
+      (item) =>
+        this.resolveAmount(item, durationSecs, nameLookup, fluidClasses),
     );
 
     const producedIn = parseClassList((cls.mProducedIn as string) || "")
@@ -498,11 +542,11 @@ export class DataParser {
       lines.push(`Produced in: ${producedIn.join(", ")}`);
     if (ingredients.length > 0)
       lines.push(
-        `Ingredients: ${ingredients.map((i) => `${i.amount}x ${i.displayName} (${i.ratePerMin}/min)`).join(", ")}`,
+        `Ingredients: ${ingredients.map((i) => this.formatAmount(i)).join(", ")}`,
       );
     if (products.length > 0)
       lines.push(
-        `Products: ${products.map((p) => `${p.amount}x ${p.displayName} (${p.ratePerMin}/min)`).join(", ")}`,
+        `Products: ${products.map((p) => this.formatAmount(p)).join(", ")}`,
       );
     lines.push(`Cycle time: ${durationSecs}s`);
 

--- a/functions/src/data/types.ts
+++ b/functions/src/data/types.ts
@@ -3,8 +3,12 @@
 export interface ResolvedAmount {
   className: string;
   displayName: string;
+  /** In-game units: item count for solids, m³ for fluids/gases (issue #22 —
+   * Docs.json stores fluid amounts in liters; the parser scales ÷1000). */
   amount: number;
   ratePerMin: number;
+  /** True when the item's form is Liquid/Gas — render as m³, not "x". */
+  isFluid?: boolean;
 }
 
 export interface ItemMetadata {


### PR DESCRIPTION
## Summary

Fixes #22, found by triaging the two thumbs-down production answers with `pnpm mine:turns`: every Liquid/Gas amount in every recipe's embedding text was 1000× too large (Docs.json stores liters, the game shows m³), and fluid extractors had the same bug. Retrieval was perfect and the model was obediently repeating tool data — the data itself was wrong.

**Changes**
- `resolveAmount` scales ÷1000 for items whose `mForm` is `RF_LIQUID`/`RF_GAS` (fluid lookup built in parse pass 1) and marks `isFluid` so text renders `3 m³ Crude Oil (30/min)` instead of `3000x Crude Oil (30000/min)`
- Fluid extractors (Water/Oil/Resource Well Extractor) scaled the same way, with a `≥1000` guard so placeholder values (Resource Well Pressurizer, `mItemsPerCycle=1`) are untouched
- Index rebuilt (`pnpm build:index`); the two triaged Q/A cases added to `eval/accuracy_dataset.json` as Layer-3 seeds (#10)

## Verification

Before → after (index embedding text):

| Recipe | Before | After (= in-game) |
|---|---|---|
| Plastic | `3000x Crude Oil (30000/min)` | `3 m³ Crude Oil (30/min)` |
| Ficsonium Fuel Rod | `20000x Excited Photonic Matter (50000/min)` | `20 m³ Excited Photonic Matter (50/min)` |
| Encased Uranium Cell | `8000x Sulfuric Acid (40000/min)` | `8 m³ Sulfuric Acid (40/min)` |
| Water Extractor | `Base extraction rate: 120000/min` | `Base extraction rate: 120 m³/min` |
| Resource Well Pressurizer | `60/min` | `60/min` (guard held) |

- 114 unit tests green (new: fluid recipe scaling, solid untouched, extractor scaling + placeholder guard)
- `pnpm verify:index` + `verify:alternates` green
- Retrieval eval gate: **Hit@5 1.00, MRR 0.923, ±0.000 vs baseline** — the text changes didn't disturb retrieval

```
  category        n   Hit@1  Hit@3  Hit@5   MRR
  factual       19    95%   100%   100%  0.965
  progression    5   100%   100%   100%  1.000
  relational     6    83%   100%   100%  0.917
  synonym        4    50%    75%   100%  0.633
  OVERALL       34    88%    97%   100%  0.923
  No misses at K=5. 🎉
```

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)